### PR TITLE
Added optional symbol param in fetch_open_orders

### DIFF
--- a/ccxtbt/ccxtstore.py
+++ b/ccxtbt/ccxtstore.py
@@ -191,8 +191,11 @@ class CCXTStore(with_metaclass(MetaSingleton, object)):
         return self.exchange.fetch_order(oid, symbol)
 
     @retry
-    def fetch_open_orders(self):
-        return self.exchange.fetchOpenOrders()
+    def fetch_open_orders(self, symbol=None):
+        if symbol == None:
+            return self.exchange.fetchOpenOrders()
+        else:
+            return self.exchange.fetchOpenOrders(symbol)
 
     @retry
     def private_end_point(self, type, endpoint, params):


### PR DESCRIPTION
Certain exchange requires symbol as mandatory parameter and currently ccxtbt does not permit user to pass in symbol parameter.
The fix is to address "Param validation for 'symbol' failed on the 'required' tag".